### PR TITLE
Add wheels for up to python 3.10 for macOS

### DIFF
--- a/.github/workflows/release-osx-pypi.yaml
+++ b/.github/workflows/release-osx-pypi.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Build and upload packages
       run: |
         eval "$(conda shell.bash hook)"
-        for VERSION in 3.6 3.7 3.8; do
+        for VERSION in 3.6 3.7 3.8 3.9 3.10; do
           conda create -n py$VERSION python=$VERSION
           conda activate py$VERSION
           python setup.py build_ext bdist_wheel


### PR DESCRIPTION
Fix for #3.

I tested the Github actions on my fork, and they looked happy up to the point where it tries to upload the wheels to pypi.